### PR TITLE
Retain access to datasettestinputs

### DIFF
--- a/processing-for-variant-discovery-gatk4.b37.trigger.json
+++ b/processing-for-variant-discovery-gatk4.b37.trigger.json
@@ -1,6 +1,6 @@
 {
-    "WorkflowUrl":"https://raw.githubusercontent.com/microsoft/gatk4-data-processing-azure/az1.1.0/processing-for-variant-discovery-gatk4.wdl",
-    "WorkflowInputsUrl":"https://raw.githubusercontent.com/microsoft/gatk4-data-processing-azure/az1.1.0/processing-for-variant-discovery-gatk4.b37.wgs.inputs.json",
+    "WorkflowUrl":"https://raw.githubusercontent.com/microsoft/gatk4-data-processing-azure/main-azure/processing-for-variant-discovery-gatk4.wdl",
+    "WorkflowInputsUrl":"https://raw.githubusercontent.com/microsoft/gatk4-data-processing-azure/main-azure/processing-for-variant-discovery-gatk4.b37.wgs.inputs.json",
     "WorkflowOptionsUrl":null,
     "WorkflowDependenciesUrl":null
 }

--- a/processing-for-variant-discovery-gatk4.b37.wgs.inputs.json
+++ b/processing-for-variant-discovery-gatk4.b37.wgs.inputs.json
@@ -2,27 +2,27 @@
   "##_COMMENT1": "SAMPLE NAME AND UNMAPPED BAMS",
   "PreProcessingForVariantDiscovery_GATK4.sample_name": "NA12878",
   "PreProcessingForVariantDiscovery_GATK4.ref_name": "b37",
-  "PreProcessingForVariantDiscovery_GATK4.flowcell_unmapped_bams_list": "/datasettestinputs/dataset/gatk4-data-processing/NA12878_downsampled_for_testing/unmapped/NA12878_downsampled.txt",
+  "PreProcessingForVariantDiscovery_GATK4.flowcell_unmapped_bams_list": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-data-processing/NA12878_downsampled_for_testing/unmapped/NA12878_downsampled.txt",
   "PreProcessingForVariantDiscovery_GATK4.unmapped_bam_suffix": ".bam",
   
   "##_COMMENT2": "REFERENCE FILES", 
-  "PreProcessingForVariantDiscovery_GATK4.ref_dict": "/datasettestinputs/dataset/references/b37/human_g1k_v37_decoy.dict",
-  "PreProcessingForVariantDiscovery_GATK4.ref_fasta": "/datasettestinputs/dataset/references/b37/human_g1k_v37_decoy.fasta",
-  "PreProcessingForVariantDiscovery_GATK4.ref_fasta_index": "/datasettestinputs/dataset/references/b37/human_g1k_v37_decoy.fasta.fai",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_sa": "/datasettestinputs/dataset/references/b37/human_g1k_v37_decoy.fasta.sa",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_amb": "/datasettestinputs/dataset/references/b37/human_g1k_v37_decoy.fasta.amb",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_bwt": "/datasettestinputs/dataset/references/b37/human_g1k_v37_decoy.fasta.bwt",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_ann": "/datasettestinputs/dataset/references/b37/human_g1k_v37_decoy.fasta.ann",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_pac": "/datasettestinputs/dataset/references/b37/human_g1k_v37_decoy.fasta.pac",
+  "PreProcessingForVariantDiscovery_GATK4.ref_dict": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/human_g1k_v37_decoy.dict",
+  "PreProcessingForVariantDiscovery_GATK4.ref_fasta": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/human_g1k_v37_decoy.fasta",
+  "PreProcessingForVariantDiscovery_GATK4.ref_fasta_index": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/human_g1k_v37_decoy.fasta.fai",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_sa": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/human_g1k_v37_decoy.fasta.sa",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_amb": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/human_g1k_v37_decoy.fasta.amb",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_bwt": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/human_g1k_v37_decoy.fasta.bwt",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_ann": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/human_g1k_v37_decoy.fasta.ann",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_pac": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/human_g1k_v37_decoy.fasta.pac",
   
   "##_COMMENT3": "KNOWN SITES RESOURCES", 
-  "PreProcessingForVariantDiscovery_GATK4.dbSNP_vcf": "/datasettestinputs/dataset/references/b37/dbsnp_138.b37.vcf",
-  "PreProcessingForVariantDiscovery_GATK4.dbSNP_vcf_index": "/datasettestinputs/dataset/references/b37/dbsnp_138.b37.vcf.idx",
+  "PreProcessingForVariantDiscovery_GATK4.dbSNP_vcf": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/dbsnp_138.b37.vcf",
+  "PreProcessingForVariantDiscovery_GATK4.dbSNP_vcf_index": "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/dbsnp_138.b37.vcf.idx",
   "PreProcessingForVariantDiscovery_GATK4.known_indels_sites_VCFs": [
-    "/datasettestinputs/dataset/references/b37/Mills_and_1000G_gold_standard.indels.b37.vcf"
+    "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/Mills_and_1000G_gold_standard.indels.b37.vcf"
   ],
   "PreProcessingForVariantDiscovery_GATK4.known_indels_sites_indices": [
-    "/datasettestinputs/dataset/references/b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx"
+    "https://datasettestinputs.blob.core.windows.net/dataset/references/b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx"
   ],
 
   "##_COMMENT4": "MISC PROGRAM PARAMETERS", 

--- a/processing-for-variant-discovery-gatk4.hg38.trigger.json
+++ b/processing-for-variant-discovery-gatk4.hg38.trigger.json
@@ -1,6 +1,6 @@
 {
-    "WorkflowUrl":"https://raw.githubusercontent.com/microsoft/gatk4-data-processing-azure/az1.1.0/processing-for-variant-discovery-gatk4.wdl",
-    "WorkflowInputsUrl":"https://raw.githubusercontent.com/microsoft/gatk4-data-processing-azure/az1.1.0/processing-for-variant-discovery-gatk4.hg38.wgs.inputs.json",
+    "WorkflowUrl":"https://raw.githubusercontent.com/microsoft/gatk4-data-processing-azure/main-azure/processing-for-variant-discovery-gatk4.wdl",
+    "WorkflowInputsUrl":"https://raw.githubusercontent.com/microsoft/gatk4-data-processing-azure/main-azure/processing-for-variant-discovery-gatk4.hg38.wgs.inputs.json",
     "WorkflowOptionsUrl":null,
     "WorkflowDependenciesUrl":null
 }

--- a/processing-for-variant-discovery-gatk4.hg38.wgs.inputs.json
+++ b/processing-for-variant-discovery-gatk4.hg38.wgs.inputs.json
@@ -2,30 +2,30 @@
   "##_COMMENT1": "SAMPLE NAME AND UNMAPPED BAMS",
   "PreProcessingForVariantDiscovery_GATK4.sample_name": "NA12878",
   "PreProcessingForVariantDiscovery_GATK4.ref_name": "hg38",
-  "PreProcessingForVariantDiscovery_GATK4.flowcell_unmapped_bams_list": "/datasettestinputs/dataset/gatk4-data-processing/NA12878_downsampled_for_testing/unmapped/NA12878_downsampled.txt",
+  "PreProcessingForVariantDiscovery_GATK4.flowcell_unmapped_bams_list": "https://datasettestinputs.blob.core.windows.net/dataset/gatk4-data-processing/NA12878_downsampled_for_testing/unmapped/NA12878_downsampled.txt",
   "PreProcessingForVariantDiscovery_GATK4.unmapped_bam_suffix": ".bam",
   
   "##_COMMENT2": "REFERENCE FILES", 
-  "PreProcessingForVariantDiscovery_GATK4.ref_dict": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.dict",
-  "PreProcessingForVariantDiscovery_GATK4.ref_fasta": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta",
-  "PreProcessingForVariantDiscovery_GATK4.ref_fasta_index": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_alt": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_sa": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_amb": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_bwt": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_ann": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
-  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_pac": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
+  "PreProcessingForVariantDiscovery_GATK4.ref_dict": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.dict",
+  "PreProcessingForVariantDiscovery_GATK4.ref_fasta": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta",
+  "PreProcessingForVariantDiscovery_GATK4.ref_fasta_index": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.fai",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_alt": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_sa": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_amb": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_bwt": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_ann": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann",
+  "PreProcessingForVariantDiscovery_GATK4.SamToFastqAndBwaMem.ref_pac": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac",
   
   "##_COMMENT3": "KNOWN SITES RESOURCES", 
-  "PreProcessingForVariantDiscovery_GATK4.dbSNP_vcf": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
-  "PreProcessingForVariantDiscovery_GATK4.dbSNP_vcf_index": "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
+  "PreProcessingForVariantDiscovery_GATK4.dbSNP_vcf": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf",
+  "PreProcessingForVariantDiscovery_GATK4.dbSNP_vcf_index": "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx",
   "PreProcessingForVariantDiscovery_GATK4.known_indels_sites_VCFs": [
-    "/datasettestinputs/dataset/references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-    "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz"
+    "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+    "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz"
   ],
   "PreProcessingForVariantDiscovery_GATK4.known_indels_sites_indices": [
-    "/datasettestinputs/dataset/references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
-    "/datasettestinputs/dataset/references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
+    "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
+    "https://datasettestinputs.blob.core.windows.net/dataset/references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
   ],
 
   "##_COMMENT4": "MISC PARAMETERS", 


### PR DESCRIPTION
`datasettestinputs`'s `dataset` container is now readable anonymously, and thus cannot be mounted on AKS. This works around that limitation.